### PR TITLE
#167689228 Build out filter trip by both origin and destination

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -60,6 +60,19 @@ export default class TripController {
 
   static getAllTrips(req, res) {
     if (dbTrip.length < 1) { return Helper.error(res, NOT_FOUND_CODE, NO_TRIP_AVAILABLE); }
+
+    const { origin } = req.query;
+    const { destination } = req.query;
+
+    // Filter trips by destination and origin
+    if (req.query.origin && req.query.destination) {
+      const result = dbTrip.filter(trip => trip.origin.toLowerCase() === origin.toLowerCase()
+      && trip.destination.toLowerCase() === destination.toLowerCase());
+
+      if (result.length < 1) { return Helper.error(res, NOT_FOUND_CODE, 'Origin and Destination Are Not Found'); }
+      return Helper.success(res, SUCCESS_CODE, result, `${result.length} result(s) Found`);
+    }
+
     return Helper.success(res, SUCCESS_CODE, dbTrip, 'Success ! WayFarer Trips !');
   }
 

--- a/server/tests/test.trip.spec.js
+++ b/server/tests/test.trip.spec.js
@@ -263,3 +263,29 @@ describe('Test case: Trip CRUD Endpoint => /api/v1/trips', () => {
         });
     });
 });
+
+describe('Users can filter trips',()=>{
+    describe('Users can filter trips by origin and destination',()=>{
+        it('Should return 200. Trip origin and destination were found',(done) =>{
+            request(app)
+            .get(`${routes.getAllTrips}?origin=Bukavu&destination=Kigali`)
+            .set('Authorization', userToken)
+            .end((err,res) =>{
+                expect(res.status).to.be.equal(SUCCESS_CODE);
+                expect(res.body).to.be.an('object');
+                done();
+            });
+        });
+
+        it('Should return 404. Trip origin does not exist',(done) =>{
+            request(app)
+            .get(`${routes.getAllTrips}?origin=Kampala&destination=Goma`)
+            .set('Authorization', userToken)
+            .end((err,res) =>{
+                expect(res.status).to.be.equal(NOT_FOUND_CODE);
+                expect(res.body).to.have.property('error');
+                done();
+            });
+        });
+    });
+});

--- a/server/tests/testBooking.js
+++ b/server/tests/testBooking.js
@@ -104,9 +104,8 @@ describe('Test case: Booking endpoint /api/v1/bookings', () => {
                 .send(correctBooking)
                 .set("Authorization", userToken)
                 .end((err, res) => {
-                    // expect(res).to.have.status(INTERNAL_SERVER_ERROR_CODE);
-                    // expect(res.body).to.have.property('status').equal(INTERNAL_SERVER_ERROR_CODE);
-                    console.log(res.body);
+                    expect(res).to.have.status(INTERNAL_SERVER_ERROR_CODE);
+                    expect(res.body).to.have.property('status').equal(INTERNAL_SERVER_ERROR_CODE);
                     
                     done();
                 });


### PR DESCRIPTION
#### What does this PR do?
It adds filter trips by origin and destination functionality to `GET /api/v1/trips` endpoint. 

#### Description of Task to be completed?
Have the following working
~ Get origin and destination query parameters
~ Validate the parameters
~ Send data to users if query was found
~ Write tests for this feature

#### How should this be manually tested?
After cloning this repository 
 - Cd into this folder with the name of this branch
- Run `npm install` to add missing dependencies
- Run `npm start` to run the server
- Run `npm test`  to test the endpoint
- Run `npm run coverage` to run coverage.
- Open Postman
- Test !

#### Any background context you want to provide?
`N/A`
#### What are the relevant pivotal tracker stories?
#167689228 