### PR TITLE
#167689319 Build filter trips by origin

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -79,6 +79,12 @@ export default class TripController {
       return Helper.success(res, SUCCESS_CODE, place, `Find ${place.length} result(s) by destination ${destination}`);
     }
 
+    if (origin) {
+      const origins = dbTrip.filter(trip => trip.origin.toLowerCase() === origin.toLowerCase());
+      if (origins.length < 1) { return Helper.error(res, NOT_FOUND_CODE, 'Origin Not Found'); }
+      return Helper.success(res, SUCCESS_CODE, origins, `Find ${origins.length} result(s) by origin : ${origin}`);
+    }
+
     return Helper.success(res, SUCCESS_CODE, dbTrip, 'Success ! WayFarer Trips !');
   }
 

--- a/server/tests/test.trip.spec.js
+++ b/server/tests/test.trip.spec.js
@@ -313,5 +313,28 @@ describe('Users can filter trips',()=>{
             });
         });
     });
+    // Filter by origin
+    describe('Users can filter trip by origin',()=>{
+        it('Should filter all trips with the given origin',(done) =>{
+            request(app)
+            .get(`${routes.getAllTrips}?origin=Bukavu`)
+            .set('Authorization', userToken)
+            .end((err,res) =>{
+                expect(res.status).to.be.equal(SUCCESS_CODE);
+                expect(res.body).to.be.an('object');
+                done();
+            });
+        });
 
+        it('Should not filter if origin does not exist',(done) =>{
+            request(app)
+            .get(`${routes.getAllTrips}?origin=Goma`)
+            .set('Authorization', userToken)
+            .end((err,res) =>{
+                expect(res.status).to.be.equal(NOT_FOUND_CODE);
+                expect(res.body).to.have.property('error').to.equal('Origin Not Found');
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
#### What does this PR do?
Adds origin filter functionality to `GET /api/v1/trips` endpoint. 

#### Description of Task to be completed?
Have the following working
~ Get origin query parameter
~ Validate parameter
~ Send data to users based on the query
~ Write tests for this feature.

#### How should this be manually tested?
After cloning this repository 
 - Cd into this folder with the name of this branch
- Run `npm install` to add missing dependencies
- Run `npm start` to run the server
- Run `npm test`  to test the endpoint
- Run `npm run coverage` to run coverage.
- Open Postman
- Navigate to this endpoint `GET` `/api/v1/trips`
- Add query `/api/v1/trips?origin=<origin>`
- Test !

#### Any background context you want to provide?
`N/A`
#### What are the relevant pivotal tracker stories?
#167689319