### PR TITLE
#167883503 View all trips from database

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -1,8 +1,9 @@
 import {
-  CREATED_CODE
+  CREATED_CODE, NOT_FOUND_CODE, SUCCESS_CODE
 } from '../constants/responseCodes';
 import Helper from '../helpers/helper';
 import TripQueries from '../models/trip';
+import { ID_NOT_FOUND } from '../constants/feedback';
 
 export default class TripController {
   static async createTrip(req, res) {
@@ -30,5 +31,20 @@ export default class TripController {
     } catch (error) {
       Helper.error(res, 409, 'Cannot insert data in db');
     }
+  }
+
+  static async cancelTrip(req, res) {
+    const queryParams = parseInt(req.params.trip_id, 10);
+    const result = await TripQueries.findOne(queryParams);
+    if (result.error) {
+      return res.status(result.error.status).json({
+        status: result.error.status,
+        error: result.error.message
+      });
+    }
+    if (result.rowCount > 0) {
+      return Helper.success(res, SUCCESS_CODE, result.rows, 'Trip cancelled successfully');
+    }
+    return Helper.error(res, NOT_FOUND_CODE, ID_NOT_FOUND);
   }
 }

--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -4,7 +4,6 @@ import {
 import Helper from '../helpers/helper';
 import TripQueries, { dbTrip } from '../models/trip';
 import { ID_NOT_FOUND, NO_TRIP_AVAILABLE } from '../constants/feedback';
-import { currentUser } from '../models/user';
 
 export default class TripController {
   static async createTrip(req, res) {
@@ -52,15 +51,11 @@ export default class TripController {
 
   static async getAllTrips(req, res) {
     const { rows } = await TripQueries.findAll();
-    const activeTrips = rows.filter(trip => trip.status === 'active');
-    let isAdmin = true;
-    currentUser.forEach((user) => { isAdmin = user.is_admin; });
-    if (!isAdmin) {
-      if (activeTrips.length > 0) {
-        return Helper.success(res, SUCCESS_CODE, activeTrips, 'Success ! WayFarer Available Trips !');
-      }
-      return Helper.error(res, NOT_FOUND_CODE, 'NO_TRIP_AVAILABLE');
+    const isAdmin = Helper.currentUserStatus();
+    const activeTrips = !isAdmin ? rows.filter(trip => trip.status === 'active') : rows;
+    if (activeTrips.length < 1) {
+      return Helper.error(res, NOT_FOUND_CODE, NO_TRIP_AVAILABLE);
     }
-    return Helper.success(res, SUCCESS_CODE, rows, 'Success ! WayFarer Trips !');
+    return Helper.success(res, SUCCESS_CODE, activeTrips, 'Success ! WayFarer Trips !');
   }
 }

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -72,10 +72,11 @@ export default class UserController {
           firstname: result.rows[0].firstname,
           lastname: result.rows[0].lastname,
           email,
-          phone_number: result.rows[0].firstname
+          phone_number: result.rows[0].firstname,
+          is_admin: isadmin
         });
         const display = Object.assign(...currentUser);
-        return Helper.success(response, SUCCESS_CODE, display, 'Welcome to Wayfarer');
+        return Helper.success(response, SUCCESS_CODE, omit(display, 'is_admin'), 'Welcome to Wayfarer');
       }
       return Helper.error(response, UNAUTHORIZED_CODE, INCORRECT_PASSWORD);
     });

--- a/server/helpers/helper.js
+++ b/server/helpers/helper.js
@@ -1,6 +1,7 @@
 import {
   UNPROCESSABLE_ENTITY
 } from '../constants/responseCodes';
+import { currentUser } from '../models/user';
 
 export default class Helper {
   static error(res, statusCode, error) {
@@ -41,5 +42,11 @@ export default class Helper {
 
     const now = `${year}-${month}-${day}`;
     return now;
+  }
+
+  static currentUserStatus() {
+    let isCurrentAdmin = true;
+    currentUser.forEach((user) => { isCurrentAdmin = user.is_admin; });
+    return isCurrentAdmin;
   }
 }

--- a/server/middlewares/permission.js
+++ b/server/middlewares/permission.js
@@ -35,4 +35,19 @@ export default class Permission {
       return Helper.error(response, UNAUTHORIZED_CODE, INVALID_TOKEN);
     }
   }
+
+  static authorize(req, res, next) {
+    const token = req.headers.authorization;
+    let currentUserID = '';
+    try {
+      const verified = jwt.verify(Helper.slice(token), process.env.JWT_KEY);
+      const { id } = verified;
+      currentUser.forEach((item) => {
+        currentUserID = item.id;
+      });
+      if (currentUserID !== id) { return Helper.error(res, UNAUTHORIZED_CODE, NOT_LOGGED_IN); }
+
+      return next();
+    } catch (error) { return Helper.error(res, UNAUTHORIZED_CODE, INVALID_TOKEN); }
+  }
 }

--- a/server/middlewares/validation.js
+++ b/server/middlewares/validation.js
@@ -1,5 +1,7 @@
 import Joi from 'joi';
 import Helper from '../helpers/helper';
+import { BAD_REQUEST_CODE } from '../constants/responseCodes';
+import { BAD_REQUEST_MSG } from '../constants/responseMessages';
 
 export default class Validator {
   static signup(request, response, next) {
@@ -62,5 +64,17 @@ export default class Validator {
 
     if (!error) { return next(); }
     return Helper.joiError(response, error);
+  }
+
+  static validateId(req, res, next) {
+    const id = req.params.trip_id || req.params.booking_id;
+    const {
+      error
+    } = Joi.validate(id, Joi.number().integer().positive().required());
+
+    if (!error) {
+      return next();
+    }
+    return Helper.error(res, BAD_REQUEST_CODE, BAD_REQUEST_MSG);
   }
 }

--- a/server/models/trip.js
+++ b/server/models/trip.js
@@ -1,7 +1,8 @@
 import { creator, pool } from './index';
-import { RESOURCE_CONFLICT, BAD_REQUEST_CODE } from '../constants/responseCodes';
-import { BUS_ALREADY_TAKEN } from '../constants/feedback';
+import { RESOURCE_CONFLICT, BAD_REQUEST_CODE, NOT_FOUND_CODE } from '../constants/responseCodes';
+import { BUS_ALREADY_TAKEN, NO_TRIP_AVAILABLE } from '../constants/feedback';
 
+export const dbTrip = [];
 export default class TripQueries {
   static async create(data) {
     const sql = `CREATE TABLE IF NOT EXISTS trips(
@@ -41,5 +42,13 @@ export default class TripQueries {
     }
     const output = await pool.query('UPDATE trips SET status = $1 WHERE id = $2 RETURNING *', ['cancelled', tripId]);
     return output;
+  }
+
+  static async findAll() {
+    const tripData = await pool.query('SELECT * FROM trips ORDER BY id ASC');
+    if (tripData.rowCount < 1) {
+      return { error: { status: NOT_FOUND_CODE, message: NO_TRIP_AVAILABLE } };
+    }
+    return tripData;
   }
 }

--- a/server/models/trip.js
+++ b/server/models/trip.js
@@ -37,7 +37,7 @@ export default class TripQueries {
     });
 
     if (isStatusCancel === 'cancelled') {
-      return { error: { status: BAD_REQUEST_CODE, message: BUS_ALREADY_TAKEN } };
+      return { error: { status: BAD_REQUEST_CODE, message: 'Trip Already Cancelled' } };
     }
     const output = await pool.query('UPDATE trips SET status = $1 WHERE id = $2 RETURNING *', ['cancelled', tripId]);
     return output;

--- a/server/models/trip.js
+++ b/server/models/trip.js
@@ -1,5 +1,5 @@
 import { creator, pool } from './index';
-import { RESOURCE_CONFLICT } from '../constants/responseCodes';
+import { RESOURCE_CONFLICT, BAD_REQUEST_CODE } from '../constants/responseCodes';
 import { BUS_ALREADY_TAKEN } from '../constants/feedback';
 
 export default class TripQueries {
@@ -27,5 +27,19 @@ export default class TripQueries {
         VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *`, data);
 
     return result;
+  }
+
+  static async findOne(tripId) {
+    const trip = await pool.query('SELECT * FROM trips WHERE id = $1', [tripId]);
+    let isStatusCancel = '';
+    trip.rows.forEach((item) => {
+      isStatusCancel = item.status;
+    });
+
+    if (isStatusCancel === 'cancelled') {
+      return { error: { status: BAD_REQUEST_CODE, message: BUS_ALREADY_TAKEN } };
+    }
+    const output = await pool.query('UPDATE trips SET status = $1 WHERE id = $2 RETURNING *', ['cancelled', tripId]);
+    return output;
   }
 }

--- a/server/routes/trip.routes.js
+++ b/server/routes/trip.routes.js
@@ -6,5 +6,6 @@ import Validator from '../middlewares/validation';
 const tripRouter = express.Router();
 
 tripRouter.post('/trips', Validator.validateTrip, Permission.grantAccess, TripController.createTrip);
+tripRouter.patch('/trips/:trip_id/cancel', Validator.validateId, Permission.grantAccess, TripController.cancelTrip);
 
 export default tripRouter;

--- a/server/routes/trip.routes.js
+++ b/server/routes/trip.routes.js
@@ -7,5 +7,6 @@ const tripRouter = express.Router();
 
 tripRouter.post('/trips', Validator.validateTrip, Permission.grantAccess, TripController.createTrip);
 tripRouter.patch('/trips/:trip_id/cancel', Validator.validateId, Permission.grantAccess, TripController.cancelTrip);
+tripRouter.get('/trips', Permission.authorize, TripController.getAllTrips);
 
 export default tripRouter;

--- a/server/tests/test.trip.spec.js
+++ b/server/tests/test.trip.spec.js
@@ -26,7 +26,7 @@ const {
     request
 } = chai;
 
-describe('Test case: Trip CRUD Endpoint => /api/v1/trips', () => {
+describe('Test case: Trip CRUD Endpoint => /api/v2/trips', () => {
     describe('Base case: Admin can create a trip', () => {
        it('Should return 201. If all fields are provided', (done) => {
         request(app)
@@ -107,6 +107,55 @@ describe('Test case: Trip CRUD Endpoint => /api/v1/trips', () => {
                     expect(res.body.error).to.be.equal(NOT_LOGGED_IN);
                     expect(res.body.status).to.be.equal(UNAUTHORIZED_CODE);
                     
+                    done();
+                });
+        });
+    });
+
+    describe('Base case: Admin can cancel a trip => /api/v2/trips/:trip_id/cancel', () => {
+        it('Should return 200. Trip was cancelled successfully', (done) => {
+            currentUser.map(user => { user.id = 1 });
+            request(app)
+                .patch('/api/v2/trips/1/cancel')
+                .set('Authorization', adminTokenId)
+                .end((err, res) => {
+                    expect(res).to.have.status(SUCCESS_CODE);
+                    expect(res.body).to.be.an('object');
+                    expect(res).to.have.headers;
+                    done();
+                });
+        });
+        it('Should return 400. Trip already successfully', (done) => {
+            request(app)
+                .patch('/api/v2/trips/1/cancel')
+                .set('Authorization', adminTokenId)
+                .end((err, res) => {
+                    expect(res).to.have.status(BAD_REQUEST_CODE);
+                    expect(res.body).to.be.an('object');
+                    expect(res).to.have.headers;
+                    done();
+                });
+        });
+        it('Should return 404. Trip Was Not Found', (done) => {
+            request(app)
+                .patch('/api/v2/trips/2/cancel')
+                .set('Authorization', adminTokenId)
+                .end((err, res) => {
+                    expect(res).to.have.status(NOT_FOUND_CODE);
+                    expect(res.body).to.be.an('object');
+                    expect(res).to.have.headers;
+                    done();
+                });
+        });
+
+        it('Should reject invalid ID', (done) => {
+            request(app)
+                .patch('/api/v2/trips/-1/cancel')
+                .set('Authorization', adminTokenId)
+                .end((err, res) => {
+                    expect(res).to.have.status(BAD_REQUEST_CODE);
+                    expect(res.body.error).to.be.equal(BAD_REQUEST_MSG);
+                    expect(res.body).to.have.property('status').equal(BAD_REQUEST_CODE)
                     done();
                 });
         });


### PR DESCRIPTION
#### What does this PR do?
Allows admin and users fetch trips from database. Administrator can view all trips, cancelled and active, while user can only view active trips.

#### Description of Task to be completed?
Have the following working
~ Build `/api/v2/trips` endpoint
~ Retrieve active trips to display to users
~ Retrieve both active and cancelled trips to display to admin
~ Handle exceptions and errors
~ Test `/api/v2/trips endpoints using Mocha and chai

#### How should this be manually tested?
After cloning this repository 
 - Cd into this folder with the name of this branch
- Run `npm install` to add missing dependencies
- Run `npm start` to run the server
- Run `npm test`  to test the endpoint
- Run `npm run coverage` to run coverage.
- Open Postman
- Use  key `Content-Type` and value `application/json`.
- Get JWT Token assigned from `/api/v2/trips endpoint`.
- Test !

#### Any background context you want to provide?
`N/A`

#### What are the relevant pivotal tracker stories?
#167883503 

#### Screenshots
![activetrips](https://user-images.githubusercontent.com/24823152/62990713-3b68e480-be4d-11e9-92dc-3c359edbab74.JPG)

